### PR TITLE
Fix DDI-C 2.5 export schema violations

### DIFF
--- a/resources/modules/formatters/ddi-c-xml.js
+++ b/resources/modules/formatters/ddi-c-xml.js
@@ -14,7 +14,7 @@ function toDdiCXml(input){
     var stdyDscr = xmlDoc.createElementNS(ns, "stdyDscr")
     var citation = xmlDoc.createElementNS(ns, "citation")
     var titlStmt = xmlDoc.createElementNS(ns, "titlStmt")
-    titlStmt.appendChild(createTextNode(xmlDoc, ns, "titl", input.fileName))
+    titlStmt.appendChild(createTextNode(xmlDoc, ns, "titl", input.studyName))
     citation.appendChild(titlStmt)
     stdyDscr.appendChild(citation)
     codeBook.appendChild(stdyDscr)

--- a/resources/modules/formatters/ddi-c-xml.js
+++ b/resources/modules/formatters/ddi-c-xml.js
@@ -11,12 +11,19 @@ function toDdiCXml(input){
     codeBook.setAttribute("xmlns:xs", "http://www.w3.org/2001/XMLSchema")
     codeBook.setAttribute("xsi:schemaLocation", "ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd")
 
+    var stdyDscr = xmlDoc.createElementNS(ns, "stdyDscr")
+    var citation = xmlDoc.createElementNS(ns, "citation")
+    var titlStmt = xmlDoc.createElementNS(ns, "titlStmt")
+    titlStmt.appendChild(createTextNode(xmlDoc, ns, "titl", input.fileName))
+    citation.appendChild(titlStmt)
+    stdyDscr.appendChild(citation)
+    codeBook.appendChild(stdyDscr)
+
     var fileDscr = xmlDoc.createElementNS(ns, "fileDscr")
     fileDscr.setAttribute("ID", input.fileName)
 
     var fileTxt = xmlDoc.createElementNS(ns, "fileTxt")
     fileTxt.appendChild(createTextNode(xmlDoc, ns, "fileName", input.fileName))
-    fileTxt.appendChild(createTextNode(xmlDoc, ns, "fileType", input.mimeType))
 
     var dataFingerprint = xmlDoc.createElementNS(ns, "dataFingerprint")
     dataFingerprint.setAttribute("type", "dataFile")
@@ -27,8 +34,9 @@ function toDdiCXml(input){
     var dimensns = xmlDoc.createElementNS(ns,"dimensns")
     dimensns.appendChild(createTextNode(xmlDoc, ns, "caseQnty", input.data.length))
     dimensns.appendChild(createTextNode(xmlDoc, ns, "varQnty", input.columns.length))
+    fileTxt.appendChild(dimensns)
 
-    fileDscr.appendChild(dimensns)
+    fileTxt.appendChild(createTextNode(xmlDoc, ns, "fileType", input.mimeType))
 
     fileDscr.appendChild(fileTxt)
     codeBook.appendChild(fileDscr)
@@ -41,7 +49,22 @@ function toDdiCXml(input){
         variable.setAttribute("ID", column.id)
         variable.setAttribute("name", column.name)
         variable.setAttribute("files", input.fileName)
-        variable.setAttribute("representationType", getVarRepresentationType(column))
+        const representationType = getVarRepresentationType(column);
+        variable.setAttribute("representationType", representationType);
+        if (representationType === "other" && column.hasIntendedDataType) {
+            const repType =
+                typeof column.hasIntendedDataType.type === "string"
+                    ? column.hasIntendedDataType.type
+                    : column.hasIntendedDataType.id;
+
+            if (typeof repType === "string") {
+                const normalized = repType.trim();
+                const lower = normalized.toLowerCase();
+                if (normalized.length > 0 && lower !== "other") {
+                    variable.setAttribute("otherRepresentationType", normalized);
+                }
+            }
+        }
 
         if(column.label){
             variable.appendChild(createTextNode(xmlDoc, ns, "labl", column.label))
@@ -87,15 +110,9 @@ function toDdiCXml(input){
             }
         }
 
-        if(column.varFormat){
-            var varFormat = xmlDoc.createElementNS(ns, "varFormat")
-            varFormat.setAttribute("type", column.varFormat.type)
-            varFormat.setAttribute("schema", column.varFormat.schema)
-            varFormat.setAttribute("otherCategory", column.varFormat.otherCategory)
-
-            variable.appendChild(varFormat)
+        if (hasAnyVarFormatInfo(column.varFormat)) {
+            variable.appendChild(createVarFormatElement(column.varFormat, xmlDoc, ns));
         }
-
 
         dataDscr.appendChild(variable)
     }
@@ -107,14 +124,59 @@ function toDdiCXml(input){
     return prolog + "\n" + formatXml(xmlString)
 }
 
-function getVarRepresentationType(column){
-    if(column.coded){
-        return "Coded"
-    }else if(column.hasIntendedDataType){
-        return column.hasIntendedDataType.id
+function getVarRepresentationType(column) {
+    if (column.coded) return "code";
+
+    const dt =
+        column && column.hasIntendedDataType
+            ? (typeof column.hasIntendedDataType.type === "string"
+                ? column.hasIntendedDataType.type
+                : column.hasIntendedDataType.id)
+            : null;
+    const repType = typeof dt === "string" ? dt.toLowerCase() : null;
+
+    const textTypes = new Set(["string"])
+    const numericTypes = new Set(["numeric", "decimal"])
+
+    if (repType === "datetime") return "datetime";
+    if (repType && textTypes.has(repType)) return "text";
+    if (repType && numericTypes.has(repType)) return "numeric";
+    return "other"
+}
+
+function hasAnyVarFormatInfo(vf) {
+    if (!vf) return false;
+    const hasType = typeof vf.type === "string" && vf.type.trim() !== "";
+    const hasSchema = typeof vf.schema === "string" && vf.schema.trim() !== "";
+    const hasOtherCat = typeof vf.otherCategory === "string" && vf.otherCategory.trim() !== "";
+    return hasType || hasSchema || hasOtherCat;
+}
+
+function createVarFormatElement(varFormat, xmlDoc, ns) {
+    const formatTypes = new Set(["character", "numeric"]);
+    const formatSchemas = new Set(["SAS", "SPSS", "IBM", "ANSI", "ISO", "XML-DATA"]);
+    const formatCategories = new Set(["date", "time", "currency", "other"]);
+
+    const el = xmlDoc.createElementNS(ns, "varFormat");
+
+    const type = typeof varFormat.type === "string" ? varFormat.type.toLowerCase() : null;
+    el.setAttribute("type", type && formatTypes.has(type) ? type : "numeric");
+
+    let schema = typeof varFormat.schema === "string" ? varFormat.schema.toUpperCase() : null;
+    if (schema && formatSchemas.has(schema)) {
+        el.setAttribute("schema", schema === "XML-DATA" ? "XML-Data" : schema);
+    } else {
+        el.setAttribute("schema", "other");
     }
 
-    return "Other"
+    const otherCategory = typeof varFormat.otherCategory === "string" ? varFormat.otherCategory.toLowerCase() : null;
+    if (otherCategory && formatCategories.has(otherCategory)) {
+        el.setAttribute("category", otherCategory);
+    } else if (otherCategory) {
+        el.setAttribute("otherCategory", otherCategory);
+    }
+
+    return el;
 }
 
 export { toDdiCXml}


### PR DESCRIPTION
- Minimal stdyDscr added
- Variable representationType and varFormat will only use values that are allowed by DDI-C 2.5 schema
- varFormat won't be added if there's no info to actually add
- Moved dimensns to correct place