### PR TITLE
Added toggle to render markdown code + added html output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@highlightjs/vue-plugin": "^2.1.0",
         "bootstrap": "^5.3.7",
         "highlight.js": "^11.11.1",
+        "marked": "^17.0.1",
         "papaparse": "^5.5.3",
         "vue": "^3.5.13",
         "webr": "^0.5.0"
@@ -1629,6 +1630,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/micromatch": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   },
   "engineStrict": true,
   "dependencies": {
+    "@highlightjs/vue-plugin": "^2.1.0",
     "bootstrap": "^5.3.7",
     "highlight.js": "^11.11.1",
-    "@highlightjs/vue-plugin": "^2.1.0",
+    "marked": "^17.0.1",
     "papaparse": "^5.5.3",
     "vue": "^3.5.13",
     "webr": "^0.5.0"

--- a/resources/App.vue
+++ b/resources/App.vue
@@ -2,6 +2,7 @@
 import { Dataset } from './models/Dataset.ts'
 import { RepresentationTypes, Parser } from './modules/utils.js'
 import { ref, reactive, computed } from 'vue'
+import { Marked } from 'marked';
 import About from './components/About.vue'
 import LoadingSpinner from './components/LoadingSpinner.vue'
 import DebugSection from './components/DebugSection.vue'
@@ -12,6 +13,8 @@ import { toDdiCdiJsonLd } from './modules/formatters/ddi-cdi-json-ld.js'
 import { toMarkdown} from './modules/formatters/markdown.js'
 import { saveFileBrowser } from './helpers/browser.ts'
 import { watch } from 'vue'
+
+
 
 
 const app = reactive({
@@ -37,8 +40,12 @@ const appMetadata = computed(() => {
 	)
 })
 
+const marked = new Marked({ gfm: true });
+
 const output = computed(() => {
 	return {
+
+		
 		filename: input.file?.name?.split('.').slice(0, -1).join('.'),
 		csv: [
 			input.dataset.columns.map(e => e.name).join(input.dataset.delimiter),
@@ -49,6 +56,7 @@ const output = computed(() => {
 		ddil : toDdiLXml(input.dataset),
 		ddi40l : toDdi40LJson(input.dataset),
 		markdown: toMarkdown(input.dataset),
+		html: marked.parse(toMarkdown(input.dataset)) // html is generated from the markdown through the "marked" library
 
 	}
 })

--- a/resources/components/DebugSection.vue
+++ b/resources/components/DebugSection.vue
@@ -1,6 +1,10 @@
 <script setup>
 import { ref, computed } from 'vue';
+import { Marked } from 'marked';
 import { saveFileBrowser, copyTextToClipboard } from '../helpers/browser.ts';
+
+
+const marked = new Marked({ gfm: true });
 
 const props = defineProps({
   output: {
@@ -29,6 +33,8 @@ const currentExport = computed(() => {
       return { content: out.ddiCdi || '', mime: 'application/json', filename: (out.filename || 'export') + '.ddi-cdi.json' };
     case 'markdown':
       return { content: out.markdown || '', mime: 'text/markdown', filename: (out.filename || 'export') + '.markdown.md' };
+    case 'html':
+      return { content: out.html || '', mime: 'text/html', filename: (out.filename || 'export') + '.html.html' };
     case 'ddi-c':
     default:
       return { content: out.ddic || '', mime: 'application/xml', filename: (out.filename || 'export') + '.ddi-codebook.2.6.xml' };
@@ -52,22 +58,33 @@ function copyCurrent() {
   <section id="debug">
     <ul class="nav nav-tabs" id="exportTabs" role="tablist">
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="csv-tab" data-bs-toggle="tab" data-bs-target="#csv-tab-pane" type="button" role="tab" aria-controls="csv-tab-pane" @click="currentTab = 'csv'"> csv (text/csv)</button>
+        <button class="nav-link" id="csv-tab" data-bs-toggle="tab" data-bs-target="#csv-tab-pane" type="button"
+          role="tab" aria-controls="csv-tab-pane" @click="currentTab = 'csv'"> csv (text/csv)</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="ddi-c-tab" data-bs-toggle="tab" data-bs-target="#ddi-c-tab-pane" type="button" role="tab" aria-controls="ddi-c-tab-pane" aria-selected="true" @click="currentTab = 'ddi-c'"> ddi-c (xml)</button>
+        <button class="nav-link active" id="ddi-c-tab" data-bs-toggle="tab" data-bs-target="#ddi-c-tab-pane"
+          type="button" role="tab" aria-controls="ddi-c-tab-pane" aria-selected="true" @click="currentTab = 'ddi-c'">
+          ddi-c (xml)</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="ddi-l-3-tab" data-bs-toggle="tab" data-bs-target="#ddi-l-3-tab-pane" type="button" role="tab" aria-controls="ddi-l-3-tab-pane" @click="currentTab = 'ddi-l-3'"> ddi-l 3.3 (xml)</button>
+        <button class="nav-link" id="ddi-l-3-tab" data-bs-toggle="tab" data-bs-target="#ddi-l-3-tab-pane" type="button"
+          role="tab" aria-controls="ddi-l-3-tab-pane" @click="currentTab = 'ddi-l-3'"> ddi-l 3.3 (xml)</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="ddi-l-4-tab" data-bs-toggle="tab" data-bs-target="#ddi-l-4-tab-pane" type="button" role="tab" aria-controls="ddi-l-4-tab-pane" @click="currentTab = 'ddi-l-4'"> ddi-l 4.0 (json)</button>
+        <button class="nav-link" id="ddi-l-4-tab" data-bs-toggle="tab" data-bs-target="#ddi-l-4-tab-pane" type="button"
+          role="tab" aria-controls="ddi-l-4-tab-pane" @click="currentTab = 'ddi-l-4'"> ddi-l 4.0 (json)</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="ddi-cdi-tab" data-bs-toggle="tab" data-bs-target="#ddi-cdi-tab-pane" type="button" role="tab" aria-controls="ddi-cdi-tab-pane" @click="currentTab = 'ddi-cdi'"> ddi-cdi (json)</button>
+        <button class="nav-link" id="ddi-cdi-tab" data-bs-toggle="tab" data-bs-target="#ddi-cdi-tab-pane" type="button"
+          role="tab" aria-controls="ddi-cdi-tab-pane" @click="currentTab = 'ddi-cdi'"> ddi-cdi (json)</button>
       </li>
       <li class="nav-item" role="presentation">
-        <button class="nav-link" id="markdown-tab" data-bs-toggle="tab" data-bs-target="#markdown-pane" type="button" role="tab" aria-controls="markdown-pane" @click="currentTab = 'markdown'"> markdown (md)</button>
+        <button class="nav-link" id="markdown-tab" data-bs-toggle="tab" data-bs-target="#markdown-pane" type="button"
+          role="tab" aria-controls="markdown-pane" @click="currentTab = 'markdown'"> markdown (md)</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="html-tab" data-bs-toggle="tab" data-bs-target="#html-pane" type="button"
+          role="tab" aria-controls="html-pane" @click="currentTab = 'html'"> html (html)</button>
       </li>
 
       <li class="nav-item ms-auto" role="presentation">
@@ -80,27 +97,73 @@ function copyCurrent() {
 
     <div class="tab-content exports">
       <div class="tab-pane fade" id="csv-tab-pane" role="tabpanel" aria-labelledby="csv-tab">
-        <highlightjs :code="output.csv" language="csv"/>
+        <highlightjs :code="output.csv" language="csv" />
       </div>
 
       <div class="tab-pane fade show active" id="ddi-c-tab-pane" role="tabpanel" aria-labelledby="ddi-c-tab">
-        <highlightjs :code="output.ddic" language="xml"/>
+        <highlightjs :code="output.ddic" language="xml" />
       </div>
 
       <div class="tab-pane fade" id="ddi-l-3-tab-pane" role="tabpanel" aria-labelledby="ddi-l-3-tab">
-        <highlightjs :code="output.ddil" language="xml"/>
+        <highlightjs :code="output.ddil" language="xml" />
       </div>
 
       <div class="tab-pane fade" id="ddi-l-4-tab-pane" role="tabpanel" aria-labelledby="ddi-l-4-tab">
-        <highlightjs :code="output.ddi40l" language="json"/>
+        <highlightjs :code="output.ddi40l" language="json" />
       </div>
 
       <div class="tab-pane fade" id="ddi-cdi-tab-pane" role="tabpanel" aria-labelledby="ddi-cdi-tab">
-        <highlightjs :code="output.ddiCdi" language="json"/>
+        <highlightjs :code="output.ddiCdi" language="json" />
       </div>
 
       <div class="tab-pane fade" id="markdown-pane" role="tabpanel" aria-labelledby="markdown-tab">
-        <highlightjs :code="output.markdown" language="md"/>
+        <ul class="nav nav-pills mb-3 mt-3" id="md-content-tab" role="tablist">
+          <li class="nav-item">
+            <a class="nav-link active" id="md-preview-tab" data-bs-toggle="pill" href="#md-preview" role="tab"
+              aria-controls="md-preview-home" aria-selected="true">Preview</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" id="md-code-tab" data-bs-toggle="pill" href="#md-code" role="tab"
+              aria-controls="md-code" aria-selected="false">Code</a>
+          </li>
+        </ul>
+        <div class="tab-content" id="pills-tabContent">
+          <div class="tab-pane fade show active" id="md-preview" role="tabpanel" aria-labelledby="md-preview-tab">
+            <!-- rendered markdown (html) -->
+            <div v-html="marked.parse(output.markdown)"></div>
+          </div>
+          <div class="tab-pane fade" id="md-code" role="tabpanel" aria-labelledby="md-code-tab">
+            <div>
+              <!-- raw code for markdown -->
+              <highlightjs :code="output.markdown" language="md" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="tab-pane fade" id="html-pane" role="tabpanel" aria-labelledby="html-tab">
+        <ul class="nav nav-pills mb-3 mt-3" id="html-content-tab" role="tablist">
+          <li class="nav-item">
+            <a class="nav-link active" id="html-preview-tab" data-bs-toggle="pill" href="#html-preview" role="tab"
+              aria-controls="md-preview-home" aria-selected="true">Preview</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" id="html-code-tab" data-bs-toggle="pill" href="#html-code" role="tab"
+              aria-controls="md-code" aria-selected="false">Code</a>
+          </li>
+        </ul>
+        <div class="tab-content" id="pills-tabContent">
+          <div class="tab-pane fade show active" id="html-preview" role="tabpanel" aria-labelledby="html-preview-tab">
+            <!-- rendered html -->
+            <div v-html="marked.parse(output.html)"></div>
+          </div>
+          <div class="tab-pane fade" id="html-code" role="tabpanel" aria-labelledby="html-code-tab">
+            <div>
+              <!-- raw code for html -->
+              <highlightjs :code="output.html" language="html" />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/resources/modules/formatters/markdown.js
+++ b/resources/modules/formatters/markdown.js
@@ -2,7 +2,7 @@
  * @param {Dataset} dataset
  */
 function toMarkdown(dataset) {
-    var md = `# "${dataset.fileName}" Codebook documentation\n\n`
+    var md = `# "${dataset.fileName}" Codebook   \n\n`
 
     md += printFileDescription(dataset)
 
@@ -28,8 +28,8 @@ function printFileDescription(dataset) {
 
 function printDimensions(dataset) {
     var mdText = `## File Dimensions \n`
-    mdText += `**Number of cases or observations:**: ${dataset.data.length}\n`
-    mdText += `**Number of variables:**: ${dataset.columns.length}\n`
+    mdText += `**Number of cases or observations:** ${dataset.data.length}  \n`
+    mdText += `**Number of variables:** ${dataset.columns.length}  \n`
     mdText += '\n'
     return mdText
 }
@@ -42,47 +42,50 @@ function printVariableStats(col) {
 
     for (var i = 0; i < statsToCompute.length; ++i) {
         var statComputed = statsToCompute[i](...columnValuesUnique);
-        mdText += `**${statsToComputeNames[i]}:** ${statComputed}\n`
+        mdText += ` - **${statsToComputeNames[i]}:** ${statComputed}  \n`
     }
     return mdText
 }
 
 
 function printVariableCodeValues(col) {
-    var mdText = `#### Code values \n`
-    mdText+= "| Code | Name | Frequency | \n"
-    mdText+= "| ---- | ---- | --------- | \n"
-     for (const codeValue of col.codeValues) {
-        mdText+=`| ${codeValue.value} |  ${codeValue.label} |  ${codeValue.frequency}| \n`
+    var mdText = ''
+    mdText += " > | Code | Name | Frequency |   \n"
+    mdText += " > | :---- | :----: | ---------: |   \n"
+    for (const codeValue of col.codeValues) {
+        mdText += " > |```" + ` ${codeValue.value}` + "```" + ` |  ${codeValue.label} |  ${codeValue.frequency}|   \n`
     }
+    mdText += "\n"
     return mdText
 }
 
 
 function printVariables(dataset) {
-    var mdText = `## Variables \n`
+    var mdText = `## Variables   \n`
 
-    for (const col of dataset.columns) {
-        mdText += `### var '${col.id}' \n`
-        mdText += `**Variable name:** ${col.name} \n`
-        mdText += `**Variable representation type:** ${getVarRepresentationType(col)} \n`
+    var ii=0
+    for (var col of dataset.columns) {
+        mdText += `#### ${ii}. '${col.id}'   \n`
+        mdText += ` - **Variable name:** ${col.name}   \n`
+        mdText += ` - **Variable representation type:** ${getVarRepresentationType(col)}   \n`
         if (col.label) {
-            mdText += `**Label:** ${col.label} \n`
+            mdText += ` - **Label:** ${col.label}   \n`
         }
         if (col.description) {
-            mdText += `**Variable description:** ${col.description} \n`
+            mdText += ` - **Variable description:** ${col.description}   \n`
         }
 
         if (col.hasIntendedDataType.type === "numeric") {
             mdText += printVariableStats(col)
         }
 
+
         if (col.codeValues && col.codeValues.length > 0) {
             mdText += printVariableCodeValues(col)
         }
 
-        mdText += '\n'
-
+        mdText += '  \n'
+        ii++
 
 
     }

--- a/resources/modules/formatters/markdown.ts
+++ b/resources/modules/formatters/markdown.ts
@@ -1,8 +1,8 @@
-/**
- * @param {Dataset} dataset
- */
-function toMarkdown(dataset) {
-    var md = `# "${dataset.fileName}" Codebook   \n\n`
+import type { Dataset } from "../../models/Dataset"
+import type { DatasetColumn } from "../../models/DatasetColumn";
+
+function toMarkdown(dataset: Dataset) {
+    let md = `# "${dataset.fileName}" Codebook   \n\n`
 
     md += printFileDescription(dataset)
 
@@ -15,8 +15,8 @@ function toMarkdown(dataset) {
     return md
 }
 
-function printFileDescription(dataset) {
-    var mdText = `## File Description \n`
+function printFileDescription(dataset: Dataset) {
+    let mdText = `## File Description \n`
     mdText += `**ID:** ${dataset.fileName}  \n`
     mdText += `**Type:** ${dataset.mimeType}  \n`
     mdText += `**Size:** ${dataset.fileSize} bytes  \n`
@@ -26,30 +26,30 @@ function printFileDescription(dataset) {
     return mdText
 }
 
-function printDimensions(dataset) {
-    var mdText = `## File Dimensions \n`
+function printDimensions(dataset: Dataset) {
+    let mdText = `## File Dimensions \n`
     mdText += `**Number of cases or observations:** ${dataset.data.length}  \n`
     mdText += `**Number of variables:** ${dataset.columns.length}  \n`
     mdText += '\n'
     return mdText
 }
 
-function printVariableStats(col) {
-    var mdText = ''
-    var columnValuesUnique = col.valuesUnique.map(Number)
-    var statsToCompute = [Math.min, Math.max]
-    var statsToComputeNames = ["Min. value", "Max. value"]
+function printVariableStats(col: DatasetColumn) {
+    let mdText = ''
+    let columnValuesUnique = col.valuesUnique.map(Number)
+    let statsToCompute = [Math.min, Math.max]
+    let statsToComputeNames = ["Min. value", "Max. value"]
 
-    for (var i = 0; i < statsToCompute.length; ++i) {
-        var statComputed = statsToCompute[i](...columnValuesUnique);
+    for (let i = 0; i < statsToCompute.length; ++i) {
+        let statComputed = statsToCompute[i](...columnValuesUnique);
         mdText += ` - **${statsToComputeNames[i]}:** ${statComputed}  \n`
     }
     return mdText
 }
 
 
-function printVariableCodeValues(col) {
-    var mdText = ''
+function printVariableCodeValues(col: DatasetColumn) {
+    let mdText = ''
     mdText += " > | Code | Name | Frequency |   \n"
     mdText += " > | :---- | :----: | ---------: |   \n"
     for (const codeValue of col.codeValues) {
@@ -60,8 +60,8 @@ function printVariableCodeValues(col) {
 }
 
 
-function printVariables(dataset) {
-    var mdText = `## Variables   \n`
+function printVariables(dataset: Dataset) {
+    let mdText = `## Variables   \n`
 
     var ii=0
     for (var col of dataset.columns) {
@@ -95,7 +95,7 @@ function printVariables(dataset) {
 }
 
 
-function getVarRepresentationType(column) {
+function getVarRepresentationType(column: DatasetColumn) {
     if (column.coded) {
         return "Coded"
     } else if (column.hasIntendedDataType) {


### PR DESCRIPTION
- Added "marked" library to packaje.json to render Markdown
- Added toggle to render Markdown as md code or html
- Fixed markdown layout on markdown.ts
- Added tab for html output
- Html output is generated 



